### PR TITLE
fix: Address SonarQube code quality issues

### DIFF
--- a/src/utils/DiscordUtils.js
+++ b/src/utils/DiscordUtils.js
@@ -15,7 +15,8 @@ class DiscordUtils {
     }
     
     // Extract user ID from mention (<@123456>) or return as-is if it's already an ID
-    const mentionMatch = userInput.match(/^<@!?(\d{17,19})>$/);
+    const mentionRegex = /^<@!?(\d{17,19})>$/;
+    const mentionMatch = mentionRegex.exec(userInput);
     if (mentionMatch) {
       return mentionMatch[1];
     }

--- a/src/utils/Logger.js
+++ b/src/utils/Logger.js
@@ -69,7 +69,7 @@ class Logger {
           formattedMessage += '\n' + chalk.gray(JSON.stringify(data, null, 2));
         } catch (error) {
           // Handle circular references or other JSON.stringify errors
-          formattedMessage += '\n' + chalk.gray('[Object with circular reference]');
+          formattedMessage += '\n' + chalk.gray(`[Object serialization failed: ${error.message}]`);
         }
       } else {
         formattedMessage += ` ${data}`;
@@ -152,7 +152,7 @@ class Logger {
           formattedMessage += '\n' + chalk.gray(JSON.stringify(data, null, 2));
         } catch (error) {
           // Handle circular references or other JSON.stringify errors
-          formattedMessage += '\n' + chalk.gray('[Object with circular reference]');
+          formattedMessage += '\n' + chalk.gray(`[Object serialization failed: ${error.message}]`);
         }
       } else {
         formattedMessage += ` ${data}`;

--- a/tests/unit/utils/Logger.test.js
+++ b/tests/unit/utils/Logger.test.js
@@ -516,10 +516,11 @@ describe('Logger', () => {
         logger.info('TEST', 'Message with circular object', circularObj);
       }).not.toThrow();
       
-      // Verify that the circular reference message was logged
+      // Verify that the serialization error message was logged
       expect(mockConsoleFunctions.log).toHaveBeenCalled();
       const logCall = mockConsoleFunctions.log.mock.calls[0][0];
-      expect(logCall).toContain('[Object with circular reference]');
+      expect(logCall).toContain('[Object serialization failed:');
+      expect(logCall).toContain('Converting circular structure to JSON');
     });
     
     test('should handle very long messages', () => {


### PR DESCRIPTION
Fix two SonarQube violations to improve code quality and maintainability:

1. RegExp.exec() instead of String.match() (javascript:S6594)
   - Replace userInput.match() with RegExp.exec() in DiscordUtils.js
   - Improves performance and follows SonarQube best practices
   - Maintains exact same functionality for Discord mention parsing

2. Proper exception handling in Logger.js
   - Use caught error information instead of ignoring it
   - Replace generic '[Object with circular reference]' message
   - Now shows '[Object serialization failed: {error.message}]'
   - Provides better debugging information for JSON.stringify failures

Changes:
- src/utils/DiscordUtils.js: Use RegExp.exec() for mention parsing
- src/utils/Logger.js: Enhanced error handling in formatMessage() and system()
- tests/unit/utils/Logger.test.js: Updated test expectations for new error messages

All tests passing with 100% coverage maintained.

🤖 Generated with [Claude Code](https://claude.ai/code)