### PR TITLE
fix: Correct SonarCloud configuration for test coverage reporting

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,14 +9,14 @@ sonar.projectVersion=1.0.0
 
 # Source code configuration
 sonar.sources=src
-sonar.tests=tests
-sonar.exclusions=**/node_modules/**,**/coverage/**,**/*.spec.js,**/*.test.js,**/docs/**,**/utils/setup.js
+sonar.tests=__tests__
+sonar.exclusions=**/node_modules/**,**/coverage/**,**/docs/**,**/utils/setup.js
 
 # Language-specific settings
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 
 # Code coverage settings
-sonar.coverage.exclusions=**/tests/**,**/*.test.js,**/*.spec.js,**/coverage/**,**/node_modules/**,**/docs/**
+sonar.coverage.exclusions=**/__tests__/**,**/*.test.js,**/*.spec.js,**/coverage/**,**/node_modules/**,**/docs/**,**/utils/setup.js
 
 # Quality profiles and gates
 sonar.qualitygate.wait=true


### PR DESCRIPTION
- Fix test directory path from 'tests' to '__tests__'
- Update coverage exclusions to match actual project structure
- Ensure LCOV report path points to correct coverage/lcov.info location
- Remove incorrect exclusions that were preventing coverage detection

This should resolve the 0% coverage issue in SonarCloud by pointing to the correct test directory and coverage report paths.

🤖 Generated with [Claude Code](https://claude.ai/code)