### PR TITLE
feat: ignore chalk major versions (breaks the code)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,10 @@ updates:
     allow:
       - dependency-type: "direct"
       - dependency-type: "indirect"
+    # Ignore breaking changes that require significant code updates
+    ignore:
+      - dependency-name: "chalk"
+        update-types: ["version-update:semver-major"]
     # Enable auto-merge for patch updates that pass tests
     # Note: This requires branch protection rules with required status checks
     assignees:


### PR DESCRIPTION
Updating toward chalk 5.x breaks the code. For now, we ignore any major version update. We'll have to update the code to be able to move on chalk 5.x.